### PR TITLE
Upgrade grin-wallet to v2.0.1-beta.4

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -340,6 +340,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +467,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,19 +571,6 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,18 +652,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin_api"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_p2p 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_pool 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_chain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_p2p 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_pool 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,8 +684,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -675,10 +693,10 @@ dependencies = [
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -689,18 +707,19 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -716,13 +735,13 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,17 +758,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_chain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -761,17 +780,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,16 +814,16 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,8 +835,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.5"
+source = "git+https://github.com/gottstech/grin?tag=v2.0.5#c8e6f22eec95fa582f92aac6e8dca587eff627fa"
 dependencies = [
  "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -832,13 +851,13 @@ dependencies = [
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_wallet"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -846,33 +865,35 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_controller 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_relay 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_api 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_controller 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_wallet_api"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,12 +901,16 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -893,27 +918,29 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_relay 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_api 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -927,17 +954,18 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -952,18 +980,20 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -974,22 +1004,21 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_relay"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1000,23 +1029,22 @@ dependencies = [
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_wallet_util"
-version = "2.0.1-alpha.2"
-source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2#5a6675eec8e28d8ce10b4f1aa1d2f6a421d2e037"
+version = "2.0.1-beta.4"
+source = "git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4#06c135aee7f0aa04b5add625dd6d3156ce8c2d1c"
 dependencies = [
  "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_api 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_chain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
+ "grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1028,26 +1056,27 @@ dependencies = [
 
 [[package]]
 name = "grinwallet_nodejs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_controller 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_relay 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
- "grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)",
+ "grin_wallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_api 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_controller 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
+ "grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)",
  "linefeed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1510,15 +1539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "msdos_time"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "neon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,31 +1771,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "openssl"
-version = "0.10.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "ordered-float"
@@ -2412,6 +2407,17 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "socket2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,7 +3025,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3069,12 +3074,11 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.4.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -3120,6 +3124,8 @@ dependencies = [
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "71152d60cec9dfdc5d9d793bccfa9ad95927372b80cd00e983db5eb2ce103e3b"
 "checksum croaring-sys 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ac84a4f975e67fc418be3911b7ca9aa74ee8a9717ca75452da7d6839421e2d67"
+"checksum crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2d818a4990769aac0c7ff1360e233ef3a41adcb009ebb2036bf6915eb0f6b23c"
+"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
@@ -3132,6 +3138,7 @@ dependencies = [
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+"checksum dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13988670860b076248c74e1b54444efc4f1dec70c8bb25da4b7c0024396b72bf"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum easy-jsonrpc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4a851f8e0ed5790b60ded487feb0dc3c7e7da52c4a0adc57c009bfc5af8ca1a"
 "checksum easy-jsonrpc-proc-macro 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9fb33793846951f339a70580375734416898ff8ddbb74401865031e25ba6751"
@@ -3143,8 +3150,6 @@ dependencies = [
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -3156,23 +3161,23 @@ dependencies = [
 "checksum getrandom 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "34f33de6f0ae7c9cb5e574502a562e2b512799e32abb801cd1e79ad952b62b49"
 "checksum git2 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cb400360e8a4d61b10e648285bbfa919bbf9519d0d5d5720354456f44349226"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_api 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24adb039b0894e95c6bfe0ac0df7f3b8dc48be696cb37798024b685ca36b3923"
-"checksum grin_chain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ae81b6a498f5d3d8c1c2f105e600d427a1717c76c282ab20e3e5eb2a35aab25"
-"checksum grin_core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06ba34fba8ea38a3ff38701761a6933649102a044f2686c21ba3947d0251aacf"
-"checksum grin_keychain 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1442f932b7488ef1bcf56eb812995cb0f0ad181ef8f08d9315954cd14929267"
-"checksum grin_p2p 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1483ca17f8479cffd360c4093f01e4a2700424bc9c07ff598de7d1805494d1e6"
-"checksum grin_pool 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b6057c01cac340e54a24749e688955712289381722a9efc225ccbaaff836996"
+"checksum grin_api 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_chain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_core 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_keychain 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_p2p 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_pool 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
 "checksum grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23027a7673df2c2b20fb9589d742ff400a10a9c3e4c769a77e9fa3bd19586822"
-"checksum grin_store 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa52e6084944cc6c67999461e763c94feaca4ff579050f85f8b79c367b15fb96"
-"checksum grin_util 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa78064c94d7331b7be4ffeed45e3341235244bac6573dda9d508abb26eba6d"
-"checksum grin_wallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_api 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_config 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_controller 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_impls 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_libwallet 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_relay 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
-"checksum grin_wallet_util 2.0.1-alpha.2 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-alpha.2)" = "<none>"
+"checksum grin_store 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_util 2.0.5 (git+https://github.com/gottstech/grin?tag=v2.0.5)" = "<none>"
+"checksum grin_wallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_api 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_config 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_controller 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_impls 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_libwallet 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_relay 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
+"checksum grin_wallet_util 2.0.1-beta.4 (git+https://github.com/gottstech/grin-wallet?tag=v2.0.1-beta.4)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -3219,7 +3224,6 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mortal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26153280e6a955881f761354b130aa7838f9983836f3de438ac0a8f22cfab1ff"
 "checksum mortal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d96ca97d37cb87ea3d658e71c8c2e2f2d420eca5deec047c5a283aa810a900ff"
-"checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 "checksum neon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "53b85accbbd250627f899a6fc1f220bbb4c8c2ff6dc71830dc6b752b39c2eb97"
 "checksum neon-build 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ae406bf1065c4399e69d328a3bd8d4f088f2a205dc3881bf68c0ac775bfef337"
 "checksum neon-runtime 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8465ac4ed3f340dead85e053b75a5f639f48ac6343b3523eff90a751758eead"
@@ -3245,8 +3249,6 @@ dependencies = [
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-"checksum openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8152bb5a9b5b721538462336e3bef9a539f892715e5037fda0f984577311af15"
-"checksum openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)" = "b5ba300217253bcc5dc68bed23d782affa45000193866e025329aa8a7a9f05b8"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
@@ -3324,6 +3326,7 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallstr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa65bb4d5b2bbc90d36af64e29802f788aa614783fa1d0df011800ddcec6e8e"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -3397,4 +3400,4 @@ dependencies = [
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
 "checksum zeroize_derive 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "080616bd0e31f36095288bb0acdf1f78ef02c2fa15527d7e993f2a6c7591643e"
-"checksum zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "36b9e08fb518a65cf7e08a1e482573eb87a2f4f8c6619316612a3c1f162fe822"
+"checksum zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3c21bb410afa2bd823a047f5bda3adb62f51074ac7e06263b2c97ecdd47e9fc6"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grinwallet_nodejs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Gary Yu <gairy.yu@gmail.com>"]
 description = "Grin Wallet Node.js Libs. With embedded Grin Relay service."
 license = "Apache-2.0"
@@ -22,6 +22,7 @@ failure_derive = "0.1"
 linefeed = "0.6"
 log = "0.4"
 prettytable-rs = "0.7"
+regex = "1"
 rpassword = "2.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1"
@@ -29,14 +30,14 @@ serde_json = "1"
 uuid = "0.7.4"
 
 # Normal using
-grin_wallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_api = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_config = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_controller = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_impls = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_libwallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_util = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
-grin_wallet_relay = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-alpha.2" }
+grin_wallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_api = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_config = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_controller = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_impls = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_libwallet = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_util = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
+grin_wallet_relay = { git = "https://github.com/gottstech/grin-wallet", tag = "v2.0.1-beta.4" }
 
 # In case of local development
 #grin_wallet_api = { path = "../../grin-wallet/api" }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -12,56 +12,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate neon;
 use neon::prelude::*;
 
+use std::sync::mpsc::{channel, TryRecvError};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use std::sync::mpsc::{channel, TryRecvError};
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uuid::Uuid;
 
 use grin_wallet_api::{Foreign, Owner};
 use grin_wallet_config::{GrinRelayConfig, WalletConfig};
+use grin_wallet_controller::{grinrelay_address, grinrelay_listener};
 use grin_wallet_impls::{
-    instantiate_wallet, Error, ErrorKind, FileWalletCommAdapter, HTTPNodeClient,
-    HTTPWalletCommAdapter, LMDBBackend, GrinrelayWalletCommAdapter, WalletSeed,
+    instantiate_wallet, Error, ErrorKind, FileWalletCommAdapter, GrinrelayWalletCommAdapter,
+    HTTPNodeClient, HTTPWalletCommAdapter, LMDBBackend, WalletSeed,
 };
 use grin_wallet_libwallet::api_impl::types::InitTxArgs;
-use grin_wallet_libwallet::{NodeClient, WalletInst, SlateVersion, VersionedSlate};
+use grin_wallet_libwallet::{NodeClient, SlateVersion, VersionedSlate, WalletInst};
 use grin_wallet_util::grin_core::global::ChainTypes;
 use grin_wallet_util::grin_keychain::ExtKeychain;
-use grin_wallet_util::grin_util::{file::get_first_line, Mutex, ZeroingString};
-use grin_wallet_controller::{grinrelay_address, grinrelay_listener};
+use grin_wallet_util::grin_util::{Mutex, ZeroingString};
 use neon::types::JsString;
 
 /// Default minimum confirmation
 pub const MINIMUM_CONFIRMATIONS: u64 = 10;
 
+/// Default sending coins selection minimum confirmation
+pub const SENDING_MINIMUM_CONFIRMATIONS: u64 = 0;
+
 fn result_to_jsresult(mut cx: FunctionContext, res: Result<String, Error>) -> JsResult<JsString> {
     match res {
-        Ok(res) => {
-            Ok(cx.string(res))
-        }
-        Err(e) => {
-            cx.throw_type_error(e.to_string())
-        }
+        Ok(res) => Ok(cx.string(res)),
+        Err(e) => cx.throw_type_error(e.to_string()),
     }
 }
 
-fn result2_to_jsresult(mut cx: FunctionContext, res: Result<(bool, String), Error>) -> JsResult<JsString> {
+fn result2_to_jsresult(
+    mut cx: FunctionContext,
+    res: Result<(bool, String), Error>,
+) -> JsResult<JsString> {
     match res {
         Ok(res) => {
             //todo: how to parse the res.0 (i.e. the is_refreshed state)
             Ok(cx.string(res.1))
         }
-        Err(e) => {
-            cx.throw_type_error(e.to_string())
-        }
+        Err(e) => cx.throw_type_error(e.to_string()),
     }
 }
 
@@ -71,6 +71,7 @@ struct MobileWalletCfg {
     chain_type: String,
     data_dir: String,
     node_api_addr: String,
+    node_api_secret: String,
     password: String,
     minimum_confirmations: u64,
     grinrelay_config: Option<GrinRelayConfig>,
@@ -100,7 +101,7 @@ fn new_wallet_config(config: MobileWalletCfg) -> Result<WalletConfig, Error> {
         api_listen_port: 3415,
         owner_api_listen_port: Some(3420),
         api_secret_path: Some(".api_secret".to_string()),
-        node_api_secret_path: Some(config.data_dir.clone() + "/.api_secret"),
+        node_api_secret: Some(config.node_api_secret),
         check_node_api_http_addr: config.node_api_addr,
         owner_api_include_foreign: Some(false),
         data_file_dir: config.data_dir + "/wallet_data",
@@ -111,6 +112,29 @@ fn new_wallet_config(config: MobileWalletCfg) -> Result<WalletConfig, Error> {
         keybase_notify_ttl: Some(1440),
         grinrelay_config: Some(config.grinrelay_config.clone().unwrap_or_default()),
     })
+}
+
+fn select_node_server(check_node_api_http_addr: &str) -> Result<String, Error> {
+    // Select nearest node server
+    if check_node_api_http_addr.starts_with("https://nodes.grin.icu") {
+        match grin_wallet_config::select_node_server(check_node_api_http_addr) {
+            Ok(best) => {
+                return Ok(best);
+            }
+            Err(e) => {
+                // error!("select_node_server fail on {}", e);
+                return Err(ErrorKind::GenericError(e.to_string()).into());
+            }
+        }
+    }
+    Ok(check_node_api_http_addr.to_owned())
+}
+
+#[no_mangle]
+pub fn select_nearest_node(mut cx: FunctionContext) -> JsResult<JsString> {
+    let check_node_api_http_addr = cx.argument::<JsString>(0)?.value();
+    let res = select_node_server(&check_node_api_http_addr);
+    result_to_jsresult(cx, res)
 }
 
 fn check_password(json_cfg: &str, password: &str) -> Result<String, Error> {
@@ -140,9 +164,15 @@ pub fn grin_init_wallet_seed(cx: FunctionContext) -> JsResult<JsString> {
 
 fn wallet_init(json_cfg: &str, password: &str, is_12_phrases: bool) -> Result<String, Error> {
     let wallet_config = new_wallet_config(MobileWalletCfg::from_str(json_cfg)?)?;
-    let node_api_secret = get_first_line(wallet_config.node_api_secret_path.clone());
+    let node_api_secret = wallet_config.node_api_secret.clone();
     let seed_length = if is_12_phrases { 16 } else { 32 };
-    let seed = WalletSeed::init_file(&wallet_config.data_file_dir, seed_length, None, password, false)?;
+    let seed = WalletSeed::init_file(
+        &wallet_config.data_file_dir,
+        seed_length,
+        None,
+        password,
+        false,
+    )?;
     let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, node_api_secret);
     let _: LMDBBackend<HTTPNodeClient, ExtKeychain> =
         LMDBBackend::new(wallet_config, password, node_client)?;
@@ -153,7 +183,7 @@ fn wallet_init(json_cfg: &str, password: &str, is_12_phrases: bool) -> Result<St
 pub fn grin_wallet_init(mut cx: FunctionContext) -> JsResult<JsString> {
     let json_cfg = cx.argument::<JsString>(0)?.value();
     let password = cx.argument::<JsString>(1)?.value();
-    let is_12_phrases= cx.argument::<JsBoolean>(2)?.value();
+    let is_12_phrases = cx.argument::<JsBoolean>(2)?.value();
 
     let res = wallet_init(&json_cfg, &password, is_12_phrases);
     result_to_jsresult(cx, res)
@@ -162,8 +192,12 @@ pub fn grin_wallet_init(mut cx: FunctionContext) -> JsResult<JsString> {
 fn wallet_init_recover(json_cfg: &str, mnemonic: &str) -> Result<String, Error> {
     let config = MobileWalletCfg::from_str(json_cfg)?;
     let wallet_config = new_wallet_config(config.clone())?;
-    WalletSeed::recover_from_phrase(&wallet_config.data_file_dir, mnemonic, config.password.as_str())?;
-    let node_api_secret = get_first_line(wallet_config.node_api_secret_path.clone());
+    WalletSeed::recover_from_phrase(
+        &wallet_config.data_file_dir,
+        mnemonic,
+        config.password.as_str(),
+    )?;
+    let node_api_secret = wallet_config.node_api_secret.clone();
     let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, node_api_secret);
     let _: LMDBBackend<HTTPNodeClient, ExtKeychain> =
         LMDBBackend::new(wallet_config, config.password.as_str(), node_client)?;
@@ -175,10 +209,7 @@ pub fn grin_wallet_init_recover(mut cx: FunctionContext) -> JsResult<JsString> {
     let json_cfg = cx.argument::<JsString>(0)?.value();
     let mnemonic = cx.argument::<JsString>(1)?.value();
 
-    let res = wallet_init_recover(
-        &json_cfg,
-        &mnemonic,
-    );
+    let res = wallet_init_recover(&json_cfg, &mnemonic);
     result_to_jsresult(cx, res)
 }
 
@@ -201,24 +232,21 @@ pub fn grin_wallet_change_password(mut cx: FunctionContext) -> JsResult<JsString
     let old_password = cx.argument::<JsString>(1)?.value();
     let new_password = cx.argument::<JsString>(2)?.value();
 
-    let res = wallet_change_password(
-        &json_cfg,
-        &old_password,
-        &new_password,
-    );
+    let res = wallet_change_password(&json_cfg, &old_password, &new_password);
     result_to_jsresult(cx, res)
 }
 
-fn wallet_restore(
-    json_cfg: &str,
-    start_index: u64,
-    batch_size: u64,
-) -> Result<String, Error> {
+fn wallet_restore(json_cfg: &str, start_index: u64, batch_size: u64) -> Result<String, Error> {
     let config = MobileWalletCfg::from_str(json_cfg)?;
     let wallet_config = new_wallet_config(config.clone())?;
-    let node_api_secret = get_first_line(wallet_config.node_api_secret_path.clone());
+    let node_api_secret = wallet_config.node_api_secret.clone();
     let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, node_api_secret);
-    let wallet = instantiate_wallet(wallet_config, node_client, config.password.as_str(), &config.account)?;
+    let wallet = instantiate_wallet(
+        wallet_config,
+        node_client,
+        config.password.as_str(),
+        &config.account,
+    )?;
     let api = Owner::new(wallet.clone());
 
     let (highest_index, last_retrieved_index, num_of_found) = api
@@ -229,7 +257,7 @@ fn wallet_restore(
         "lastRetrievedIndex": last_retrieved_index,
         "numberOfFound": num_of_found,
     })
-        .to_string())
+    .to_string())
 }
 
 #[no_mangle]
@@ -241,11 +269,7 @@ pub fn grin_wallet_restore(mut cx: FunctionContext) -> JsResult<JsString> {
     let start_index = start_index as u64;
     let batch_size = batch_size as u64;
 
-    let res = wallet_restore(
-        &json_cfg,
-        start_index,
-        batch_size,
-    );
+    let res = wallet_restore(&json_cfg, start_index, batch_size);
     result_to_jsresult(cx, res)
 }
 
@@ -265,7 +289,7 @@ fn wallet_check(
         "highestIndex": highest_index,
         "lastRetrievedIndex": last_retrieved_index,
     })
-        .to_string())
+    .to_string())
 }
 
 #[no_mangle]
@@ -278,12 +302,7 @@ pub fn grin_wallet_check(mut cx: FunctionContext) -> JsResult<JsString> {
     let start_index = start_index as u64;
     let batch_size = batch_size as u64;
 
-    let res = wallet_check(
-        &json_cfg,
-        start_index,
-        batch_size,
-        update_outputs,
-    );
+    let res = wallet_check(&json_cfg, start_index, batch_size, update_outputs);
     result_to_jsresult(cx, res)
 }
 
@@ -304,9 +323,9 @@ pub fn grin_get_wallet_mnemonic(mut cx: FunctionContext) -> JsResult<JsString> {
 
 fn get_wallet_instance(
     config: MobileWalletCfg,
-) -> Result<Arc<Mutex<WalletInst<impl NodeClient, ExtKeychain>>>, Error> {
+) -> Result<Arc<Mutex<dyn WalletInst<impl NodeClient, ExtKeychain>>>, Error> {
     let wallet_config = new_wallet_config(config.clone())?;
-    let node_api_secret = get_first_line(wallet_config.node_api_secret_path.clone());
+    let node_api_secret = wallet_config.node_api_secret.clone();
     let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, node_api_secret);
 
     instantiate_wallet(
@@ -345,10 +364,7 @@ pub fn grin_tx_retrieve(mut cx: FunctionContext) -> JsResult<JsString> {
     let json_cfg = cx.argument::<JsString>(0)?.value();
     let tx_slate_id = cx.argument::<JsString>(1)?.value();
 
-    let res = tx_retrieve(
-        &json_cfg,
-        &tx_slate_id,
-    );
+    let res = tx_retrieve(&json_cfg, &tx_slate_id);
     result_to_jsresult(cx, res)
 }
 
@@ -444,9 +460,7 @@ pub fn grin_init_tx(mut cx: FunctionContext) -> JsResult<JsString> {
     result_to_jsresult(cx, res)
 }
 
-fn listen(
-    json_cfg: &str,
-) -> Result<String, Error> {
+fn listen(json_cfg: &str) -> Result<String, Error> {
     let config = MobileWalletCfg::from_str(json_cfg)?;
     let wallet = get_wallet_instance(config.clone())?;
 
@@ -454,11 +468,12 @@ fn listen(
     let (relay_tx_as_payee, relay_rx) = channel();
 
     // Start a Grin Relay service firstly
-    let grinrelay_listener = grinrelay_listener(
+    let (grinrelay_key_path, grinrelay_listener) = grinrelay_listener(
         wallet.clone(),
         config.grinrelay_config.clone().unwrap_or_default(),
         None,
         Some(relay_tx_as_payee),
+        None,
     )?;
 
     let _handle = thread::spawn(move || {
@@ -468,26 +483,32 @@ fn listen(
                 Ok((addr, slate)) => {
                     let _slate_id = slate.id;
                     if api.verify_slate_messages(&slate).is_ok() {
-                        let slate_rx = api.receive_tx(&slate, Some(&config.account), None);
+                        let slate_rx = api.receive_tx(
+                            &slate,
+                            Some(&config.account),
+                            None,
+                            Some(grinrelay_key_path),
+                        );
                         if let Ok(slate_rx) = slate_rx {
                             let versioned_slate =
                                 VersionedSlate::into_version(slate_rx.clone(), SlateVersion::V2);
-                            let res = grinrelay_listener.publish(&versioned_slate, &addr.to_owned());
+                            let res =
+                                grinrelay_listener.publish(&versioned_slate, &addr.to_owned());
                             match res {
                                 Ok(_) => {
-//                                    info!(
-//                                        "Slate [{}] sent back to {} successfully",
-//                                        slate_id.to_string().bright_green(),
-//                                        addr.bright_green(),
-//                                    );
+                                    //info!(
+                                    //    "Slate [{}] sent back to {} successfully",
+                                    //    slate_id.to_string().bright_green(),
+                                    //    addr.bright_green(),
+                                    //);
                                 }
                                 Err(_e) => {
-//                                    error!(
-//                                        "Slate [{}] fail to sent back to {} for {}",
-//                                        slate_id.to_string().bright_green(),
-//                                        addr.bright_green(),
-//                                        e,
-//                                    );
+                                    //error!(
+                                    //    "Slate [{}] fail to sent back to {} for {}",
+                                    //    slate_id.to_string().bright_green(),
+                                    //    addr.bright_green(),
+                                    //    e,
+                                    //);
                                 }
                             }
                         }
@@ -500,9 +521,9 @@ fn listen(
         }
     });
 
-//    if handle.is_err() {
-//        Err(ErrorKind::GenericError("Listen thread fail to start".to_string()).into())?
-//    }
+    //if handle.is_err() {
+    //    Err(ErrorKind::GenericError("Listen thread fail to start".to_string()).into())?
+    //}
     Ok("OK".to_owned())
 }
 
@@ -514,9 +535,7 @@ pub fn grin_listen(mut cx: FunctionContext) -> JsResult<JsString> {
     result_to_jsresult(cx, res)
 }
 
-fn relay_addr(
-    json_cfg: &str,
-) -> Result<String, Error> {
+fn relay_addr(json_cfg: &str) -> Result<String, Error> {
     let config = MobileWalletCfg::from_str(json_cfg)?;
     let wallet = get_wallet_instance(config.clone())?;
     Ok(grinrelay_address(
@@ -533,6 +552,129 @@ pub fn grin_relay_addr(mut cx: FunctionContext) -> JsResult<JsString> {
     result_to_jsresult(cx, res)
 }
 
+fn relay_addr_query(json_cfg: &str, six_code_suffix: &str) -> Result<String, Error> {
+    let mut is_valid_six_code = false;
+    if six_code_suffix.len() == 6 {
+        let re = Regex::new(r"[02-9ac-hj-np-z]{6}").unwrap();
+        let captures = re.captures(six_code_suffix);
+        if captures.is_some() {
+            is_valid_six_code = true;
+        }
+    }
+    if !is_valid_six_code {
+        return Err(ErrorKind::GenericError("invalid 6-code address".to_owned()).into());
+    }
+
+    let config = MobileWalletCfg::from_str(json_cfg)?;
+    let wallet = get_wallet_instance(config.clone())?;
+
+    {
+        let (relay_addr_query_sender, relay_addr_query_rx) = channel();
+
+        // Start a Grin Relay service firstly
+        let (_key_path, listener) = grinrelay_listener(
+            wallet.clone(),
+            config.grinrelay_config.clone().unwrap_or_default(),
+            None,
+            None,
+            Some(relay_addr_query_sender),
+        )?;
+
+        // Wait for connecting with relay service
+        let mut wait_time = 0;
+        while !listener.is_connected() {
+            thread::sleep(Duration::from_millis(100));
+            wait_time += 1;
+            if wait_time > 50 {
+                return Err(ErrorKind::GenericError(
+                    "Fail to connect with grin relay service, 5s timeout. please try again later"
+                        .to_owned(),
+                )
+                .into());
+            }
+        }
+
+        // Conversion the 6-code abbreviation address to the full address
+        {
+            let abbr = six_code_suffix.clone();
+            if listener.retrieve_relay_addr(abbr.to_string()).is_err() {
+                return Err(ErrorKind::GenericError(
+                    "Fail to send query request for abbreviated relay addr!".to_owned(),
+                )
+                .into());
+            }
+
+            const TTL: u16 = 10;
+            let mut addresses: Option<Vec<String>> = None;
+            let mut cnt = 0;
+            loop {
+                match relay_addr_query_rx.try_recv() {
+                    Ok((_abbr, addrs)) => {
+                        if !addrs.is_empty() {
+                            addresses = Some(addrs);
+                        }
+                        break;
+                    }
+                    Err(TryRecvError::Disconnected) => break,
+                    Err(TryRecvError::Empty) => {}
+                }
+                cnt += 1;
+                if cnt > TTL * 10 {
+                    //info!(
+                    //    "{} from relay server for address query. {}s timeout",
+                    //    "No response".bright_blue(),
+                    //    TTL
+                    //);
+                    return Err(ErrorKind::GenericError(
+                        "relay server no response, please try again later".to_owned(),
+                    )
+                    .into());
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+
+            if let Some(addresses) = addresses {
+                match addresses.len() {
+                    0 => {
+                        return Err(ErrorKind::ArgumentError(
+                            "wrong address, or destination is offline".to_owned(),
+                        )
+                        .into());
+                    }
+                    1 => {
+                        let dest = addresses.first().unwrap().clone();
+                        return Ok(dest);
+                    }
+                    _ => {
+                        //warn!(
+                        //   "{} addresses matched the same abbreviation address: {:?}",
+                        //    addresses.len(),
+                        //    addresses,
+                        //);
+                        return Err(ErrorKind::ArgumentError(
+                            "address conflict, multiple matched addresses found".to_owned(),
+                        )
+                        .into());
+                    }
+                }
+            } else {
+                return Err(ErrorKind::ArgumentError(
+                    "wrong address, or destination is offline".to_owned(),
+                )
+                .into());
+            }
+        }
+    }
+}
+
+#[no_mangle]
+pub fn grin_relay_addr_query(mut cx: FunctionContext) -> JsResult<JsString> {
+    let json_cfg = cx.argument::<JsString>(0)?.value();
+    let six_code_suffix = cx.argument::<JsString>(1)?.value();
+    let res = relay_addr_query(&json_cfg, &six_code_suffix);
+    result_to_jsresult(cx, res)
+}
+
 fn send_tx_by_http(
     json_cfg: &str,
     amount: u64,
@@ -546,7 +688,7 @@ fn send_tx_by_http(
     let args = InitTxArgs {
         src_acct_name: None,
         amount,
-        minimum_confirmations: MINIMUM_CONFIRMATIONS,
+        minimum_confirmations: SENDING_MINIMUM_CONFIRMATIONS,
         max_outputs: 500,
         num_change_outputs: 1,
         selection_strategy: selection_strategy.to_string(),
@@ -558,27 +700,37 @@ fn send_tx_by_http(
     let slate_r1 = api.init_send_tx(args)?;
 
     let adapter = HTTPWalletCommAdapter::new();
-    match adapter.send_tx_sync(receiver_wallet_url, &slate_r1) {
-        Ok(slate) => {
-            api.verify_slate_messages(&slate)?;
-            api.tx_lock_outputs(&slate_r1, 0)?;
+    let (slate, _tx_proof) = adapter.send_tx_sync(receiver_wallet_url, &slate_r1)?;
+    api.verify_slate_messages(&slate)?;
+    api.tx_lock_outputs(&slate_r1, 0)?;
 
-            let finalized_slate = api.finalize_tx(&slate);
-            if finalized_slate.is_err() {
-                api.cancel_tx(None, Some(slate_r1.id))?;
-            }
-            let finalized_slate = finalized_slate?;
+    let finalized_slate = api.finalize_tx(&slate, None, None);
+    if finalized_slate.is_err() {
+        api.cancel_tx(None, Some(slate_r1.id))?;
+    }
+    let finalized_slate = finalized_slate?;
 
-            let res = api.post_tx(&finalized_slate.tx, false);
-            if res.is_err() {
-                api.cancel_tx(None, Some(slate_r1.id))?;
-                res?;
-            }
-
-            Ok(serde_json::to_string(&finalized_slate).expect("fail to serialize slate to json string"))
+    let res = api.post_tx(Some(finalized_slate.id), &finalized_slate.tx, true);
+    match res {
+        Ok(_) => {
+            //info!("Tx sent ok",);
+            return Ok(serde_json::to_string(&finalized_slate)
+                .expect("fail to serialize slate to json string"));
         }
         Err(e) => {
-            Err(Error::from(e))
+            // re-post last unconfirmed txs and try again
+            if let Ok(true) = api.repost_last_txs(true, false) {
+                // iff one re-post success, post this transaction again
+                if let Ok(_) = api.post_tx(Some(finalized_slate.id), &finalized_slate.tx, true) {
+                    //info!("Tx sent ok (with last unconfirmed tx/s re-post)");
+                    return Ok(serde_json::to_string(&finalized_slate)
+                        .expect("fail to serialize slate to json string"));
+                }
+            }
+
+            //error!("Tx sent fail on post.");
+            let _ = api.cancel_tx(None, Some(finalized_slate.id));
+            return Err(ErrorKind::GenericError(e.to_string()).into());
         }
     }
 }
@@ -597,7 +749,7 @@ fn send_tx_by_relay(
     let args = InitTxArgs {
         src_acct_name: None,
         amount,
-        minimum_confirmations: MINIMUM_CONFIRMATIONS,
+        minimum_confirmations: SENDING_MINIMUM_CONFIRMATIONS,
         max_outputs: 500,
         num_change_outputs: 1,
         selection_strategy: selection_strategy.to_string(),
@@ -612,36 +764,59 @@ fn send_tx_by_relay(
     let (relay_tx_as_payer, relay_rx) = channel();
 
     // Start a Grin Relay service firstly
-    let grinrelay_listener = grinrelay_listener(
+    let (grinrelay_key_path, grinrelay_listener) = grinrelay_listener(
         wallet.clone(),
         config.grinrelay_config.clone().unwrap_or_default(),
         Some(relay_tx_as_payer),
         None,
+        None,
     )?;
-    thread::sleep(Duration::from_millis(1_000));
+    // Wait for connecting with relay service
+    let mut wait_time = 0;
+    while !grinrelay_listener.is_connected() {
+        thread::sleep(Duration::from_millis(100));
+        wait_time += 1;
+        if wait_time > 50 {
+            return Err(ErrorKind::GenericError(
+                "Fail to connect with grin relay service, 5s timeout. please try again later"
+                    .to_owned(),
+            )
+            .into());
+        }
+    }
 
     let adapter = GrinrelayWalletCommAdapter::new(grinrelay_listener, relay_rx);
-    match adapter.send_tx_sync(receiver_addr, &slate_r1.clone()) {
-        Ok(mut slate) => {
-            api.verify_slate_messages(&slate)?;
-            api.tx_lock_outputs(&slate_r1, 0)?;
+    let (slate, tx_proof) = adapter.send_tx_sync(receiver_addr, &slate_r1.clone())?;
+    api.verify_slate_messages(&slate)?;
+    api.tx_lock_outputs(&slate_r1, 0)?;
 
-            let finalized_slate = api.finalize_tx(&mut slate);
-            if finalized_slate.is_err() {
-                api.cancel_tx(None, Some(slate_r1.id))?;
-            }
-            let finalized_slate = finalized_slate?;
+    let finalized_slate = api.finalize_tx(&slate, tx_proof, Some(grinrelay_key_path));
+    if finalized_slate.is_err() {
+        api.cancel_tx(None, Some(slate_r1.id))?;
+    }
+    let finalized_slate = finalized_slate?;
 
-            let res = api.post_tx(&finalized_slate.tx, false);
-            if res.is_err() {
-                api.cancel_tx(None, Some(slate_r1.id))?;
-                res?;
-            }
-
-            Ok(serde_json::to_string(&finalized_slate).expect("fail to serialize slate to json string"))
+    let res = api.post_tx(Some(finalized_slate.id), &finalized_slate.tx, true);
+    match res {
+        Ok(_) => {
+            //info!("Tx sent ok",);
+            return Ok(serde_json::to_string(&finalized_slate)
+                .expect("fail to serialize slate to json string"));
         }
         Err(e) => {
-            Err(Error::from(e))
+            // re-post last unconfirmed txs and try again
+            if let Ok(true) = api.repost_last_txs(true, false) {
+                // iff one re-post success, post this transaction again
+                if let Ok(_) = api.post_tx(Some(finalized_slate.id), &finalized_slate.tx, true) {
+                    //info!("Tx sent ok (with last unconfirmed tx/s re-post)");
+                    return Ok(serde_json::to_string(&finalized_slate)
+                        .expect("fail to serialize slate to json string"));
+                }
+            }
+
+            //error!("Tx sent fail on post.");
+            let _ = api.cancel_tx(None, Some(finalized_slate.id));
+            return Err(ErrorKind::GenericError(e.to_string()).into());
         }
     }
 }
@@ -718,7 +893,7 @@ fn post_tx(json_cfg: &str, tx_slate_id: &str) -> Result<String, Error> {
     let stored_tx = api.get_stored_tx(&txs[0])?;
     match stored_tx {
         Some(stored_tx) => {
-            api.post_tx(&stored_tx, false)?;
+            api.post_tx(Some(uuid), &stored_tx, true)?;
             Ok("OK".to_owned())
         }
         None => Err(Error::from(ErrorKind::GenericError(format!(
@@ -732,25 +907,23 @@ pub fn grin_post_tx(mut cx: FunctionContext) -> JsResult<JsString> {
     let json_cfg = cx.argument::<JsString>(0)?.value();
     let tx_slate_id = cx.argument::<JsString>(1)?.value();
 
-    let res = post_tx(
-        &json_cfg,
-        &tx_slate_id,
-    );
+    let res = post_tx(&json_cfg, &tx_slate_id);
     result_to_jsresult(cx, res)
 }
 
-fn tx_file_receive(
-    json_cfg: &str,
-    slate_file_path: &str,
-    message: &str,
-) -> Result<String, Error> {
+fn tx_file_receive(json_cfg: &str, slate_file_path: &str, message: &str) -> Result<String, Error> {
     let config = MobileWalletCfg::from_str(json_cfg)?;
     let wallet = get_wallet_instance(config.clone())?;
     let api = Foreign::new(wallet, None);
     let adapter = FileWalletCommAdapter::new();
     let mut slate = adapter.receive_tx_async(&slate_file_path)?;
     api.verify_slate_messages(&slate)?;
-    slate = api.receive_tx(&slate, Some(&config.account), Some(message.to_string()))?;
+    slate = api.receive_tx(
+        &slate,
+        Some(&config.account),
+        Some(message.to_string()),
+        None,
+    )?;
     Ok(serde_json::to_string(&slate).expect("fail to serialize slate to json string"))
 }
 
@@ -760,24 +933,17 @@ pub fn grin_tx_file_receive(mut cx: FunctionContext) -> JsResult<JsString> {
     let slate_file_path = cx.argument::<JsString>(1)?.value();
     let message = cx.argument::<JsString>(2)?.value();
 
-    let res = tx_file_receive(
-        &json_cfg,
-        &slate_file_path,
-        &message,
-    );
+    let res = tx_file_receive(&json_cfg, &slate_file_path, &message);
     result_to_jsresult(cx, res)
 }
 
-fn tx_file_finalize(
-    json_cfg: &str,
-    slate_file_path: &str,
-) -> Result<String, Error> {
+fn tx_file_finalize(json_cfg: &str, slate_file_path: &str) -> Result<String, Error> {
     let wallet = get_wallet_instance(MobileWalletCfg::from_str(json_cfg)?)?;
     let api = Owner::new(wallet);
     let adapter = FileWalletCommAdapter::new();
     let mut slate = adapter.receive_tx_async(slate_file_path)?;
     api.verify_slate_messages(&slate)?;
-    slate = api.finalize_tx(&slate)?;
+    slate = api.finalize_tx(&slate, None, None)?;
     Ok(serde_json::to_string(&slate).expect("fail to serialize slate to json string"))
 }
 
@@ -786,10 +952,7 @@ pub fn grin_tx_file_finalize(mut cx: FunctionContext) -> JsResult<JsString> {
     let json_cfg = cx.argument::<JsString>(0)?.value();
     let slate_file_path = cx.argument::<JsString>(1)?.value();
 
-    let res = tx_file_finalize(
-        &json_cfg,
-        &slate_file_path,
-    );
+    let res = tx_file_finalize(&json_cfg, &slate_file_path);
     result_to_jsresult(cx, res)
 }
 
@@ -823,6 +986,7 @@ register_module!(mut cx, {
     cx.export_function("grinOutputsRetrieve", grin_outputs_retrieve)?;
     cx.export_function("grinListen", grin_listen)?;
     cx.export_function("grinRelayAddr", grin_relay_addr)?;
+    cx.export_function("grinRelayAddrQuery", grin_relay_addr_query)?;
     cx.export_function("grinInitTx", grin_init_tx)?;
     cx.export_function("grinSendTx", grin_send_tx)?;
     cx.export_function("grinCancelTx", grin_cancel_tx)?;


### PR DESCRIPTION
* Upgrade grin-wallet to [v2.0.1-beta.4](https://github.com/gottstech/grin-wallet/releases/tag/v2.0.1-beta.4)
* New API: `grinRelayAddrQuery` for short relay address query, which can be used as the online/offline query also.